### PR TITLE
bug fix

### DIFF
--- a/src/AtmScatter/CRTM_AerosolScatter.f90
+++ b/src/AtmScatter/CRTM_AerosolScatter.f90
@@ -952,12 +952,13 @@ CONTAINS
                    asi%xlp,          & ! FWD Input
                    r_TL, r_int_TL,   & ! TL  Input
                    xlp_TL            ) ! TL  Output
-    ! Size variance term
+    ! Size variance term    
+    IF ( AeroC%Scheme == 'CMAQ' ) THEN 
     CALL LPoly_TL( asi%v, asi%v_int, & ! FWD Input
                    asi%vlp,          & ! FWD Input
                    v_TL, v_int_TL,   & ! TL  Input
                    vlp_TL            ) ! TL  Output
-
+    END IF
 
     ! Get the aerosol type LUT index
     ! ------------------------------


### PR DESCRIPTION
## Description

Bugfix: add **IF 'CAMQ'** condition to the index interpretation for radii variance, in module **get_aerosol_opt_tl.**

Without this bug fix, CRTM 2.4 still produces the correct TL results if complied without debug flags.
If complied with debug flags, CRTM 2.4 will stop and report error:

```
Program received signal SIGFPE: Floating-point exception - erroneous arithmetic operation.

Backtrace for this error:
#0  0x7F061AA5EC47
#1  0x7F061AA5DE40
#2  0x7F0619F533FF
#3  0x8BF745 in __crtm_interpolation_MOD_compute_qpoly_tl at CRTM_Interpolation.f90:1100 (discriminator 10)
#4  0x8C12F0 in __crtm_interpolation_MOD_lpoly_tl at CRTM_Interpolation.f90:946 (discriminator 4)
#5  0x6D0182 in __crtm_aerosolscatter_MOD_get_aerosol_opt_tl at CRTM_AerosolScatter.f90:959
#6  0x6DC159 in __crtm_aerosolscatter_MOD_crtm_compute_aerosolscatter_tl at CRTM_AerosolScatter.f90:485 (discriminator 8)
#7  0x4F7D66 in __crtm_tangent_linear_module_MOD_crtm_tangent_linear at CRTM_Tangent_Linear_Module.f90:875
#8  0x420B8A in __crtm_testing_MOD_crtm_consistency_test at CRTM_V2.4alpha.f90:304
#9  0x431BFF in MAIN__ at CRTM_V2.4alpha.f90:887
Floating point exception
```
This error was triggered by a test from Mark Liu