### PR TITLE
update public develop with public master hotfix

### DIFF
--- a/cmake/compiler_flags_GNU_Fortran.cmake
+++ b/cmake/compiler_flags_GNU_Fortran.cmake
@@ -38,7 +38,7 @@ set( CMAKE_Fortran_FLAGS_BIT     "-O2 -funroll-all-loops -finline-functions" )
 # LINK FLAGS
 ####################################################################
 
-set( CMAKE_Fortran_LINK_FLAGS    "-fopenmp" )
+set( CMAKE_Fortran_LINK_FLAGS    "-fopenmp -fPIC" )
 
 ####################################################################
 

--- a/src/CRTM_Version.inc
+++ b/src/CRTM_Version.inc
@@ -1,1 +1,1 @@
-#define CRTM_VERSION 'v2.4.0-alpha'
+#define CRTM_VERSION 'v2.4.0'


### PR DESCRIPTION
## Description

Keeping public develop up to date with master after hotfix for crtm bundle.  Adds -fPIC flag for gfortran.setup.   This creates a libcrtm.so file instead  of a libcrtm.a file.  

Will probably need to add a similar flag for ifort, or consider making it an option in case people want a static library (.a) instead of a shared library (.so).  



