### PR TITLE
Added ecbuild availability to test/CMakeLists.txt.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,12 @@ enable_testing ()
 
 ## Ecbuild integration
 find_package( ecbuild QUIET )
+if(NOT ecbuild_FOUND)
+	message(WARNING "ecbuild is required for testing and was not found!")
+	message(WARNING "CRTM tests are disabled!")
+	return()
+endif()
+
 include( ecbuild_system NO_POLICY_SCOPE )
 ecbuild_declare_project()
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )


### PR DESCRIPTION
## Description

This PR adds the following check to `test/CMakeLists.txt`:
```cmake
if(NOT ecbuild_FOUND)
  message(WARNING "ecbuild is required for testing and was not found!")
  message(WARNING "CRTM tests are disabled!")
  return()
endif()
```
If an ecbuild installation is not found, the CRTM ctests are not built and a warning message is produced.

## Definition of Done

The ecbuild check is included in `test/CMakeLists.txt`.

### Issue(s) addressed

N/A

## Dependencies

N/A

## Impact

None.
