### PR TITLE
exposing planck function in CRTM_Module.f90 for Erin Jones (@erinjones2)

### DIFF
--- a/libsrc/CRTM_Module.F90
+++ b/libsrc/CRTM_Module.F90
@@ -35,7 +35,8 @@ MODULE CRTM_Module
   USE CRTM_K_Matrix_Module
   ! ...The aerosol optical depth tool
   USE CRTM_AOD_Module
-
+  ! ...Planck Functions
+  USE CRTM_Planck_Functions
 
   ! Visibility
   ! ----------


### PR DESCRIPTION
Expose the planck function in CRTM_Module.F90.

@erinjones2 This PR replicates what you were trying to accomplish with your other PR. I'll close that PR, and we'll just use this.

However, you should know that REL-2.4.0_emc has "flat" structure that EMC has typically preferred to use compared to the "development" structure that we're now using in CRTM. The main difference being that there's no "src/" directory here, it's just "libsrc/"

