### PR TITLE
Check that OPTIONAL arguments are PRESENT

### DIFF
--- a/src/CRTM_LifeCycle.f90
+++ b/src/CRTM_LifeCycle.f90
@@ -603,10 +603,12 @@ CONTAINS
 
     ! Load the cloud coefficients
     IF ( Local_Load_CloudCoeff ) THEN
-      IF (.not. Quiet) THEN
-        WRITE(*, '("Load the cloud coefficients: ") ')
-        WRITE(*, '("...Cloud model: ", a) ') TRIM(Default_Cloud_Model)
-        WRITE(*, '("...CloudCoeff file: ", a) ') TRIM(Default_CloudCoeff_File)
+      IF (PRESENT(Quiet)) THEN
+        IF (.not. Quiet) THEN
+          WRITE(*, '("Load the cloud coefficients: ") ')
+          WRITE(*, '("...Cloud model: ", a) ') TRIM(Default_Cloud_Model)
+          WRITE(*, '("...CloudCoeff file: ", a) ') TRIM(Default_CloudCoeff_File)
+        END IF
       END IF
       err_stat = CRTM_CloudCoeff_Load( &
                    Default_Cloud_Model                  , &
@@ -625,10 +627,12 @@ CONTAINS
 
     ! Load the aerosol coefficients
     IF ( Local_Load_AerosolCoeff ) THEN
-      IF (.not. Quiet) THEN
-        WRITE(*, '("Load the aerosol coefficients: ") ')
-        WRITE(*, '("...Aerosol model: ", a) ') TRIM(Default_Aerosol_Model)
-        WRITE(*, '("...AerosolCoeff file: ", a) ') TRIM(Default_AerosolCoeff_File)
+      IF (PRESENT(Quiet)) THEN
+        IF (.not. Quiet) THEN
+          WRITE(*, '("Load the aerosol coefficients: ") ')
+          WRITE(*, '("...Aerosol model: ", a) ') TRIM(Default_Aerosol_Model)
+          WRITE(*, '("...AerosolCoeff file: ", a) ') TRIM(Default_AerosolCoeff_File)
+        END IF
       END IF
       err_stat = CRTM_AerosolCoeff_Load( &
                    Default_Aerosol_Model                , &


### PR DESCRIPTION
## Description

This is a somewhat trivial change that fixes segfaults in most CRTM ctests in v2.4.0 when compiled using the Intel 2023.1 classic compiler. `Quiet` is an optional function argument, and its presence needs to be verified before dereferencing in an IF statement.

I realize that v2.4.1 is out already, and that ufo gained the ability to use v2.4.1 today as part of [JCSDA-internal/ufo#2779](https://github.com/JCSDA/ufo/commit/4efd156624bae8a6f81ca2a6ca696df94c2609f1) (thanks @BenjaminTJohnson), but I think it's good to note for users on the latest Skylab tag.