### PR TITLE
update config for gfortran on Apple Silicon

### DIFF
--- a/configuration/gfortran-debug.setup
+++ b/configuration/gfortran-debug.setup
@@ -11,14 +11,14 @@ if [[ "$uname" == "Linux"  ]] ; then
 		export NC4_DIR=/usr/local/ #singularity container only
 		export HDF_DIR=/usr/local/ #singularity container only
 elif [[ "$uname" == "Darwin" ]] ; then
-		export NC4_DIR="/usr/local/Cellar/netcdf/4.7.4_1"  #mac OS, brew install
-		export HDF_DIR="/usr/local/Cellar/hdf5/1.12.0_1"   #mac OS, brew install
+		export NC4_DIR=$(nf-config|awk 'BEGIN{FS="->\ "};/\-\-prefix/ {print $2}')  #mac OS (brew install)
+		export HDF_DIR=$(h5fc -showconfig|awk 'BEGIN{FS=":\ "};/Installation point/ {print $2}')   #mac OS (brew install)
 fi
 
 #set the number of openmp threads
 export OMP_NUM_THREADS=4  #set here for testing purposes, probably want to override this
 
-export FCFLAGS="\
+FCFLAGS="\
 -fbounds-check \
 -mieee-fp \
 -fimplicit-none \
@@ -31,6 +31,10 @@ export FCFLAGS="\
 -Wall \
 -Wconversion \
 -std=f2008"
+if [[ "$(uname -m)" == "arm64"  ]] ; then 
+    FCFLAGS=$(echo $FCFLAGS | sed 's/-mieee-fp//g') # remove -mieee-fp flag for arm (i.e.,apple silicon) gfortran
+fi
+export FCFLAGS
 
 export LDFLAGS="-fopenmp"
 

--- a/configuration/gfortran.setup
+++ b/configuration/gfortran.setup
@@ -11,14 +11,14 @@ if [[ "$uname" == "Linux"  ]] ; then
 		export NC4_DIR=/usr/local #singularity container only
 		export HDF_DIR=/usr/local #singularity container only
 elif [[ "$uname" == "Darwin" ]] ; then
-		export NC4_DIR="/usr/local/Cellar/netcdf/4.7.4_1"  #mac OS (brew install)
-		export HDF_DIR="/usr/local/Cellar/hdf5/1.12.0_1"   #mac OS (brew install)
+		export NC4_DIR=$(nf-config|awk 'BEGIN{FS="->\ "};/\-\-prefix/ {print $2}')  #mac OS (brew install)
+		export HDF_DIR=$(h5fc -showconfig|awk 'BEGIN{FS=":\ "};/Installation point/ {print $2}')   #mac OS (brew install)
 fi
 
 #set the number of openmp threads
 export OMP_NUM_THREADS=4  #set here for testing purposes, probably want to override this
 
-export FCFLAGS="\
+FCFLAGS="\
 -O3 \
 -fimplicit-none \
 -ffree-form \
@@ -31,6 +31,10 @@ export FCFLAGS="\
 -mieee-fp \
 -fbounds-check \
 -std=f2008"
+if [[ "$(uname -m)" == "arm64"  ]] ; then 
+    FCFLAGS=$(echo $FCFLAGS | sed 's/-mieee-fp//g') # remove -mieee-fp flag for arm (i.e.,apple silicon) gfortran
+fi
+export FCFLAGS
 
 export LDFLAGS="-fopenmp"
 


### PR DESCRIPTION
## Description
I'm building the REL-2.4.0 following the steps documented in `REDME.md` instead of using `ecbuild`. 
When running `./configure --prefix=${PWD}` in the **Build Step 1**, I got the following error
```
configure: error: Fortran compiler cannot create executables
```
The error tracing back shows that this was due to the compling flag `-mieee-fp` (`FCFLAGS` in `configuration/gfortran*.setup`) not supported by gfortran 12.2.0/13.1.0 on my Apple Silicon Macbook Pro.
After removing this flag, the CRTM can be built successfully.

The corrected one has been tested in three envs (Section Machine & env tested, both arm and non-arm) and passed building tests.

### Changes made:
1. One additional check is added to `configuration/gfortran.setup` and `configuration/gfortran-debug.setup` to see if the computer arch is arm64-based. If so, drop the`-mieee-fp` flag
2. Besides, remove the hard-coded approach to get `NC4_DIR` and `HDF_DIR` in `configuration/gfortran*.setup`.

### Machine & env tested:
1. Apple Silicon M1 Pro + Mac OS Monterey 12.6.5 + Homebrew gcc version 13.1.0 (Homebrew GCC 13.1.0)
2. Apple Silicon M1 Pro + Mac OS Monterey 12.6.5 + Homebrew gcc version 12.2.0 (Homebrew GCC 12.2.0)
3. Intel 6700 + ubuntu 22.04 LTS + gcc version 11.0
 

## Issue(s) addressed

Resolves #39 

## Dependencies

List the other PRs that this PR is dependent on: N/A

## Impact

None. This PR only changes compiling flags on Macbook Pro Apple Silicon

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR

I don't know how to run the unit tests if not using the `ecbuild` approach.
