### PR TITLE
Update SpcCoeff_Binary_IO.f90

### DIFF
--- a/libsrc/SpcCoeff_Binary_IO.f90
+++ b/libsrc/SpcCoeff_Binary_IO.f90
@@ -397,7 +397,7 @@ CONTAINS
       CALL Read_Cleanup(); RETURN
     END IF
     ! ...Read the channel data
-    IF( dummy%Version > 2 ) THEN
+    IF( dummy%Version > 3 ) THEN
       ! Binary coefficient version 3 introduced for TROPICS instrument.
       ! The SpcCoeff coefficients contain 'PolAngle' as an additional
       ! array.
@@ -414,7 +414,7 @@ CONTAINS
         SpcCoeff%Band_C2                   , &
         SpcCoeff%Cosmic_Background_Radiance, &
         SpcCoeff%Solar_Irradiance
-    ELSE IF( dummy%Version < 3 ) THEN
+    ELSE IF( dummy%Version < 4 ) THEN
       ! Version 2 is the default binary SpcCoeff version for 
       ! REL-2.4.0 and older.
       READ ( fid, IOSTAT=io_stat, IOMSG=io_msg ) &


### PR DESCRIPTION
Fix version numbers for read

There is a bug in [SpcCoeff_Binary_IO.f90](https://github.com/JCSDA/crtm/blob/hotfix/btj_REL-2.4.0_emc_polangle/libsrc/SpcCoeff_Binary_IO.f90). Specifically these lines:

IF( dummy%Version > 2 ) THEN
! Binary coefficient version 3 introduced for TROPICS instrument.
! The SpcCoeff coefficients contain 'PolAngle' as an additional
! array.
READ ( fid, IOSTAT=io_stat, IOMSG=io_msg ) &
SpcCoeff%Sensor_Channel , &
SpcCoeff%Polarization , &
SpcCoeff%PolAngle , &
SpcCoeff%Channel_Flag , &
SpcCoeff%Frequency , &
SpcCoeff%Wavenumber , &
SpcCoeff%Planck_C1 , &
SpcCoeff%Planck_C2 , &
SpcCoeff%Band_C1 , &
SpcCoeff%Band_C2 , &
SpcCoeff%Cosmic_Background_Radiance, &
SpcCoeff%Solar_Irradiance
ELSE IF( dummy%Version < 3 ) THEN
! Version 2 is the default binary SpcCoeff version for
! REL-2.4.0 and older.
READ ( fid, IOSTAT=io_stat, IOMSG=io_msg ) &
SpcCoeff%Sensor_Channel , &
SpcCoeff%Polarization , &
SpcCoeff%Channel_Flag , &
SpcCoeff%Frequency , &
SpcCoeff%Wavenumber , &
SpcCoeff%Planck_C1 , &
SpcCoeff%Planck_C2 , &
SpcCoeff%Band_C1 , &
SpcCoeff%Band_C2 , &
SpcCoeff%Cosmic_Background_Radiance, &
SpcCoeff%Solar_Irradiance

Most of the versions in fix/SpcCoeff/Big_Endian are 8.02 or (for ATMS_N21) 8.04, but amsua_metop-b is version 8.03, so dummy%Version=3. This file does not contain PolAngle, which is why the code crashes.

The comment says that version 3 should include this field, so I do not know which is right. But changing dummy%Version > 2 to dummy%Version > 3 allows the file to be read in.

Also not that the IF( dummy%Version < 4 ) does not actually do anything (this will always be true).

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
